### PR TITLE
Make Fedora, Solr configuration more consistent and flexible

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -3,7 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/development" %>
 test: &test
   adapter: solr
-  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,15 +1,15 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: <%= ENV['FEDORA_URL'] || 'http://127.0.0.1:8983/fedora/rest' %>
   base_path: /dev
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8983/fedora/rest
+  url: <%= ENV['FEDORA_URL'] || 'http://127.0.0.1:8983/fedora/rest' %>
   base_path: /test
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: <%= ENV['FEDORA_URL'] || 'http://127.0.0.1:8983/fedora/rest' %>
   base_path: /prod

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://localhost:8983/solr/development
+  url: <%= ENV['SOLR_URL'] || 'http://127.0.0.1:8983/solr/development' %>
 test:
-  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>
+  url: <%= ENV['SOLR_URL'] || 'http://127.0.0.1:8983/solr/test' %>
 production:
-  url: http://your.production.server:8080/bl_solr/core0
+  url: <%= ENV['SOLR_URL'] || 'http://your.production.server:8080/bl_solr/core0' %>


### PR DESCRIPTION
The configuration files for Fedora, Solr and Blacklight contain a hodge-podge of environmental customization hooks that look like they were added at various times by various developers to solve local issues, without any overall design effort.  I've tried to make the customization more consistent and able to cope with a broader range of configuration needs.

(I needed this because I'm using free-standing Fedora and Solr instances to work around ongoing hydra-jetty issues)

The effect of this should be that, if you are using hydra-jetty and don't set any of the environment variables, you should see no change, while if you need to point elsewhere you can now consistently use complete URLs for Solr and Fedora across all Rails environments (develop, test, etc) and both services.

The default production settings are still inconsistent between Solr and Blacklight.  That seemed like a separate issue.
