### PR TITLE
HPT-684: Changing creator to multiple as expected by Curation Concerns

### DIFF
--- a/app/models/paged_media/paged_work_behavior.rb
+++ b/app/models/paged_media/paged_work_behavior.rb
@@ -3,7 +3,7 @@ module PagedMedia::PagedWorkBehavior
   include Hydra::Works::WorkBehavior
 
   included do
-    property :creator, predicate: ::RDF::DC.creator, multiple: false
+    property :creator, predicate: ::RDF::DC.creator, multiple: true
     #property :author, predicate: ::RDF::DC.creator, multiple: false
   end
 

--- a/spec/factories/paged_work_factories.rb
+++ b/spec/factories/paged_work_factories.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
   #Create a paged_work object
   factory :paged_work, class: PagedWork do
     title ["Paged Work Object"]
-    creator "Factory Girl"
+    creator ["Factory Girl"]
     depositor "user@example.com"
     edit_users ["user@example.com"]
     #author "Factory Girl"


### PR DESCRIPTION
Paged Work behavior was setting creator to singular but the new form partials in updated Curation Concerns creates multiple, so an exception is thrown on new work creation.
