### PR TITLE
FOR DISCUSSION: Stub code, rake tasks for very basic ingest

### DIFF
--- a/app/views/curation_concerns/paged_works/show.html.erb
+++ b/app/views/curation_concerns/paged_works/show.html.erb
@@ -13,9 +13,9 @@
 
 <ul>
 <% @members.each do |member| %>
-  <% model_name = member['has_model_ssim'][0].downcase %>
+  <% model_name = member.class.to_s.tableize %>
   <li>
-    <%= link_to member['title_tesim'].first.to_s, eval("main_app.curation_concerns_#{model_name}_path('" + member['id'] + "')") %>
+    <%= link_to member.title.first.to_s, eval("main_app.curation_concerns_#{model_name}_path('" + member.id + "')") %>
   </li>
 <% end %>
 </ul>

--- a/lib/tasks/paged_media.rake
+++ b/lib/tasks/paged_media.rake
@@ -1,5 +1,6 @@
 require 'rspec/core'
 require 'rspec/core/rake_task'
+require './lib/tasks/paged_media/ingest'
 
 namespace :paged_media do
   desc 'Paged Media rspec task'
@@ -14,6 +15,11 @@ namespace :paged_media do
         end
       end
     end
+  end
+
+  desc 'Run ingest'
+  task :ingest => :environment do
+    PagedMedia::Ingest::Tasks.ingest
   end
 
 end

--- a/lib/tasks/paged_media/ingest.rb
+++ b/lib/tasks/paged_media/ingest.rb
@@ -1,0 +1,49 @@
+require 'pp'
+module PagedMedia
+  module Ingest
+    module Tasks
+      def Tasks.ingest
+        puts "Ingest folders found: #{Helpers.ingest_folders.inspect}"
+        Helpers::ingest_folders.each do |subdir|
+          puts "Running ingest for subfolder: #{subdir}"
+          manifest_files = Dir.glob(subdir + "/" + "manifest*.yml").select { |f| File.file?(f) }
+          puts "Manifest files found: #{manifest_files.inspect}"
+          manifest_files.each do |manifest_file|
+            puts "Manifest file: #{manifest_file}"
+            manifest = YAML.load_file(manifest_file)
+            objects = Helpers.objects_from_hash(manifest)
+            objects.each do |object|
+              puts "#{object.class}: #{object.title.inspect}"
+              pp object.relationship_tree(:members, :title, [])
+            end
+          end
+        end
+      end
+    end
+    module Helpers
+      def Helpers.ingest_folders
+        ingest_root = "spec/fixtures/ingest/paged_media/"
+        return Dir.glob(ingest_root + "*").select { |f| File.directory?(f) }
+      end
+      def Helpers.objects_from_hash(objects_hash)
+        objects_hash.inject([]) do |results_array, (object_class, attributes)|
+          object = object_class.to_s.classify.constantize.new
+          attributes.each do |att, val|
+            case att
+            when 'ordered_members'
+              val.each do |member_hash|
+                Helpers.objects_from_hash(member_hash).each do |member|
+                  object.ordered_members << member
+                end
+              end
+            else
+              object.send("#{att}=", val)
+            end
+          end
+          object.save!
+          results_array << object
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/ingest/paged_media/package1/manifest_nested.yml
+++ b/spec/fixtures/ingest/paged_media/package1/manifest_nested.yml
@@ -1,0 +1,38 @@
+---
+paged_work:
+  title:
+  - Nested Title 1
+  creator:
+  - Nested Author 1
+  depositor: user@example.com
+  edit_users:
+  - user@example.com
+  visibility: open
+  ordered_members:
+  - container:
+      title: Nested Container 1
+      ordered_members:
+      - file_set:
+          depositor: user@example.com
+          edit_users:
+          - user@example.com
+          title: 
+          - Nested File Set 1
+      - container:
+          title: Nested Container 2
+          ordered_members:
+          - file_set:
+              depositor: user@example.com
+              edit_users:
+              - user@example.com
+              title: 
+              - Nested File Set 2
+  - container:
+      title: Nested Container 3
+      ordered_members:
+      - file_set:
+          depositor: user@example.com
+          edit_users:
+          - user@example.com
+          title:
+          - Nested File Set 3

--- a/spec/fixtures/ingest/paged_media/package1/manifest_simple.yml
+++ b/spec/fixtures/ingest/paged_media/package1/manifest_simple.yml
@@ -1,0 +1,29 @@
+---
+paged_work:
+  title:
+  - Simple Title 1
+  creator:
+  - Simple Author 1
+  depositor: user@example.com
+  edit_users:
+  - user@example.com
+  visibility: open
+  ordered_members:
+  - file_set:
+      depositor: user@example.com
+      edit_users:
+        - user@example.com
+      title: 
+        - Simple File Set 1
+  - file_set:
+      depositor: user@example.com
+      edit_users:
+        - user@example.com
+      title: 
+        - Simple File Set 2
+  - file_set:
+      depositor: user@example.com
+      edit_users:
+        - user@example.com
+      title: 
+        - Simple File Set 3


### PR DESCRIPTION
This is not meant to be merged yet, but to serve as a basis for review and discussion.

This pull request contains a basic stub of working ingest, for 2 example manifests.  (Note that the "simple" one displays okay in the "show" page for the work, while the "nested" other does not -- but this is just an issue with the show page, itself, handling Containers.)  Notably missing:
- Files are not attached to FileSets
- Ingest code can generally use refactoring, yarddoc compliance, rubocop compliance

But it works enough to hopefully serve as the basis for discussion, with the goal of stabilizing the first version of the ingest yml format sufficient to work on the other stories about converting pre-ingest newspaper, musical score packages into ingest.  Once that is achieved, ingest code can be refactored in parallel with pre-ingest stories.

Topics to consider:
- YAML format:
  - Does this look overall like the approach we want to take?  A basic dump of attributes, relationships that ingest can pretty blindly plug-and-chug with?
- Ingest logic:
  - How much (if any) responsibility does it need to bear for validating the format?  Or is that assumed to have been handled in the pre-ingest stage?
  - How much output, logging is desired?
  - Does it need to bear any responsibility for identifying and using existing objects vs creating new ones?  This pertains primarily to existing collections that a paged_work might be added to.
    - If that's handled in the pre-ingest stage, ingest could be simple and just use an existing object if an "id" value is supplied, and create a new one otherwise
