### PR TITLE
[HPT-734][HPT-735] Adds file information to contentDM preingest file + add ingest code to handle this info.

### DIFF
--- a/app/controllers/curation_concerns/newspapers_controller.rb
+++ b/app/controllers/curation_concerns/newspapers_controller.rb
@@ -4,4 +4,10 @@
 class CurationConcerns::NewspapersController < ApplicationController
   include CurationConcerns::CurationConcernController
   self.curation_concern_type = Newspaper
+
+  def show
+    super
+    @cont_json = Newspaper.find(@presenter.id).cont_array.to_json
+  end
+
 end

--- a/app/controllers/curation_concerns/newspapers_controller.rb
+++ b/app/controllers/curation_concerns/newspapers_controller.rb
@@ -4,10 +4,4 @@
 class CurationConcerns::NewspapersController < ApplicationController
   include CurationConcerns::CurationConcernController
   self.curation_concern_type = Newspaper
-
-  def show
-    super
-    @cont_json = Newspaper.find(@presenter.id).cont_array.to_json
-  end
-
 end

--- a/lib/tasks/paged_media/ingest.rb
+++ b/lib/tasks/paged_media/ingest.rb
@@ -33,12 +33,23 @@ module PagedMedia
           attributes.each do |att, val|
             case att
             when 'file'
-              file_path = "#{subdir}/content/#{val}"
-              Hydra::Works::UploadFileToFileSet.call(object, File.open(file_path))
+              if val.instance_of? String
+                file_path = "#{subdir}/content/#{val}"
+                Hydra::Works::UploadFileToFileSet.call(object, File.open(file_path))
+              end
             when 'ordered_members'
               val.each do |member_hash|
                 Helpers.objects_from_hash(member_hash, subdir).each do |member|
                   object.ordered_members << member
+                end
+              end
+            when 'files'
+              val.each do |file_hash|
+                file_path = file_hash['file']['path'].to_s
+                file_type = file_hash['file']['type'].to_s
+                if file_type.eql? "thumbnail"
+                  file = open(file_path)
+                  Hydra::Works::UploadFileToFileSet.call(object, file)
                 end
               end
             else

--- a/lib/tasks/paged_media/ingest.rb
+++ b/lib/tasks/paged_media/ingest.rb
@@ -47,10 +47,9 @@ module PagedMedia
               val.each do |file_hash|
                 file_path = file_hash['file']['path'].to_s
                 file_type = file_hash['file']['type'].to_s
-                if file_type.eql? "thumbnail"
-                  file = open(file_path)
-                  Hydra::Works::UploadFileToFileSet.call(object, file)
-                end
+                # TODO - Extend code to hanlde and "label" multiple files
+                file = open(file_path)
+                Hydra::Works::UploadFileToFileSet.call(object, file)
               end
             else
               object.send("#{att}=", val)

--- a/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
+++ b/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
@@ -44,6 +44,8 @@ module PagedMedia
           page['file_set'] = {}
           page['file_set']['title'] = page_xml.xpath('pagetitle').map(&:content)
           page['file_set']['visibility'] = 'open'
+          files = self.add_files(page_xml)
+          page['file_set']['files'] = files
           pages << page
         end
         return pages
@@ -53,12 +55,44 @@ module PagedMedia
       # @param [XML_Object] page_xml node to parse
       # @return [Array] of files to add to page
       def ContentdmNewspaper.add_files(page_xml)
-        # TODO - Will add URL to pull in files (page image, thumbnail, extracted text)
-        files[] = []
+        files = []
         page_xml.xpath('pagefile').each do |pagefile_xml|
-
+          pagefile_type = pagefile_xml.xpath('pagefiletype').map(&:content).first.to_s
+          file_type = ''
+          case pagefile_type
+          when 'thumbnail'
+            file_type = pagefile_type
+          when 'access'
+            file_type = 'image'
+          else
+            next
+          end
+          file = {}
+          file['file'] = {}
+          file['file']['type'] = file_type
+          path = pagefile_xml.xpath('pagefilelocation').map(&:content).first.to_s
+          file['file']['path'] = self.fix_path_iupui(path)
+          files << file
         end
         return files
+      end
+      # Pull out fulltext from export file
+      #
+      # @param [Type]  describe
+      # @return [Type] description of returned object
+      def ContentdmNewspaper.extra_fulltest()
+        # TODO Pull out fulltext from import file and create file to be saved
+      end
+      # Fix file paths for IUPUI exports
+      #
+      # @param [String] path given from IUPUI contentDM export
+      # @return [String] corrected path using new API port for IUPUI contentDM
+      def ContentdmNewspaper.fix_path_iupui(path)
+        # IUPUI CDM no longer provides API on port 445
+        # The API is now available on port 2012
+        # Also need to replace &amp; with just &
+        path = path.sub(/445\/cgi-bin/, '2012/cgi-bin')
+        path = path.sub('&amp;', '&')
       end
       # Create manifext file from preingested data
       # for contentDM newspapers export

--- a/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
+++ b/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
@@ -64,6 +64,8 @@ module PagedMedia
             file_type = pagefile_type
           when 'access'
             file_type = 'image'
+            # TODO - When ingest can handle multiple files, include actual image.
+            next
           else
             next
           end

--- a/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
+++ b/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
@@ -35,7 +35,7 @@ module PagedMedia
       end
       # Create pages array to be added to issue/newspaper
       #
-      # @param [XML_Object] pages_xml to parse
+      # @param [XML_Object] for pages to parse
       # @return [Array] of pages to add to issue/newspaper
       def ContentdmNewspaper.add_pages(pages_xml)
         pages = []
@@ -52,7 +52,7 @@ module PagedMedia
       end
       # Create array of files to add to page
       #
-      # @param [XML_Object] page_xml node to parse
+      # @param [XML_Object] for page node to parse
       # @return [Array] of files to add to page
       def ContentdmNewspaper.add_files(page_xml)
         files = []
@@ -80,7 +80,7 @@ module PagedMedia
       #
       # @param [Type]  describe
       # @return [Type] description of returned object
-      def ContentdmNewspaper.extra_fulltest()
+      def ContentdmNewspaper.content_fulltext()
         # TODO Pull out fulltext from import file and create file to be saved
       end
       # Fix file paths for IUPUI exports
@@ -90,7 +90,7 @@ module PagedMedia
       def ContentdmNewspaper.fix_path_iupui(path)
         # IUPUI CDM no longer provides API on port 445
         # The API is now available on port 2012
-        # Also need to replace &amp; with just &
+        # Also needs to replace &amp; with just &
         path = path.sub(/445\/cgi-bin/, '2012/cgi-bin')
         path = path.sub('&amp;', '&')
       end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -2,6 +2,10 @@ describe Collection do
   let(:collection) {FactoryGirl.create :collection}
   let(:complete_collection) {FactoryGirl.create :complete_collection}
 
+  after(:each) do
+    Collection.destroy_all
+  end
+    
   describe 'FactoryGirl' do
     describe ':colllection' do
       it 'is a Collection' do

--- a/spec/models/paged_media/object_behavior_spec.rb
+++ b/spec/models/paged_media/object_behavior_spec.rb
@@ -21,6 +21,9 @@ describe PagedMedia::ObjectBehavior do
     so1.ordered_members = [so2]
     so2.member_of = [so1]
   end
+  after(:each) do
+    Collection.destroy_all
+  end 
   let(:test_ancestor) { so0 }
   let(:children) { test_ancestor.ordered_members.to_a }
   let(:children_and_grandchildren) do

--- a/spec/models/paged_media/object_behavior_spec.rb
+++ b/spec/models/paged_media/object_behavior_spec.rb
@@ -21,9 +21,9 @@ describe PagedMedia::ObjectBehavior do
     so1.ordered_members = [so2]
     so2.member_of = [so1]
   end
-  after(:each) do
+  after(:all) do
     Collection.destroy_all
-  end 
+  end
   let(:test_ancestor) { so0 }
   let(:children) { test_ancestor.ordered_members.to_a }
   let(:children_and_grandchildren) do


### PR DESCRIPTION
Right now this commit is hard coded to only ingest thumbnail files for a newspaper collection. A couple of future stories will pull in multiple files as well as create and pull in full text for each page. 
