### PR TITLE
[HPT-736] Speed up spec testing so it's not too painful to use

### DIFF
--- a/spec/tasks/ingest_spec.rb
+++ b/spec/tasks/ingest_spec.rb
@@ -1,6 +1,6 @@
 require './lib/tasks/paged_media/ingest'
 
-describe PagedMedia::Ingest do
+describe PagedMedia::Ingest, :integration, :ingest do
   describe PagedMedia::Ingest::Tasks do
     describe '.ingest' do
       it 'adds 2 PagedWork objects' do

--- a/spec/tasks/preingest_spec.rb
+++ b/spec/tasks/preingest_spec.rb
@@ -3,7 +3,7 @@ require './lib/tasks/paged_media/ingest'
 
 PREINGEST_CHANGES = { Collection => 1, Newspaper => 5, MusicalScore => 2 }
 
-describe PagedMedia::PreIngest do
+describe PagedMedia::PreIngest, :integration, :ingest do
   describe PagedMedia::PreIngest::Tasks do
     describe '.preingest' do
       before(:all) do


### PR DESCRIPTION
Our tests have become very heavy and developers are complaining.  Unit testing should run quickly enough to avoid interrupting a train of thought.
