### PR TITLE
[HPT-730] Adds ability to ingest multi files into one file set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ pickle-email-*.html
 /spec/fixtures/ingest/*/manifest*.yml
 !spec/fixtures/ingest/package1/*
 
+#Exclude preingest full text files
+/spec/fixtures/ingest/*/content/fulltext
+
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/secrets.yml

--- a/lib/tasks/paged_media/ingest.rb
+++ b/lib/tasks/paged_media/ingest.rb
@@ -47,9 +47,14 @@ module PagedMedia
               val.each do |file_hash|
                 file_path = file_hash['file']['path'].to_s
                 file_type = file_hash['file']['type'].to_s
-                # TODO - Extend code to hanlde and "label" multiple files
                 file = open(file_path)
-                Hydra::Works::UploadFileToFileSet.call(object, file)
+                if file_type.eql?('thumbnail')
+                  Hydra::Works::AddFileToFileSet.call(object, file, :thumbnail)
+                elsif file_type.eql?('original')
+                  Hydra::Works::AddFileToFileSet.call(object, file, :original_file)
+                elsif file_type.eql?('extracted')
+                  Hydra::Works::AddFileToFileSet.call(object, file, :extracted_text)
+                end
               end
             else
               object.send("#{att}=", val)

--- a/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
+++ b/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
@@ -22,29 +22,37 @@ module PagedMedia
       # Create a single issue/newpaper array to be added to collection
       #
       # @param [XML_Object] record xml node to parse
+      # @param [String] fulltext_content_dir directory to story full text
       # @return [Hash] issue to be added
-      def ContentdmNewspaper.add_newspaper(record)
+      def ContentdmNewspaper.add_newspaper(record, fulltext_content_dir)
+        title = record.xpath('title').map(&:content).first.to_s
+        newspaper_content_dir = "#{fulltext_content_dir}/#{title}"
+        FileUtils.mkdir_p(newspaper_content_dir) unless File.exists?(newspaper_content_dir)
         issue = {}
         issue['newspaper'] = {}
-        issue['newspaper']['title'] = record.xpath('title').map(&:content)
+        issue['newspaper']['title'] = [title]
         issue['newspaper']['visibility'] = 'open'
         issue['newspaper']['creator'] = record.xpath('publisher').map(&:content)
-        pages = self.add_pages(record.xpath('structure'))
+        pages = self.add_pages(record.xpath('structure'), newspaper_content_dir)
         issue['newspaper']['ordered_members'] = pages
         return issue
       end
       # Create pages array to be added to issue/newspaper
       #
       # @param [XML_Object] for pages to parse
+      # @param [String] content_dir directory for full text
       # @return [Array] of pages to add to issue/newspaper
-      def ContentdmNewspaper.add_pages(pages_xml)
+      def ContentdmNewspaper.add_pages(pages_xml, content_dir)
         pages = []
         pages_xml.xpath('page').each do |page_xml|
+          title = page_xml.xpath('pagetitle').map(&:content).first.to_s
+          page_content_dir = "#{content_dir}/#{title}"
+          FileUtils.mkdir_p(page_content_dir) unless File.exists?(page_content_dir)
           page = {}
           page['file_set'] = {}
-          page['file_set']['title'] = page_xml.xpath('pagetitle').map(&:content)
+          page['file_set']['title'] = [title]
           page['file_set']['visibility'] = 'open'
-          files = self.add_files(page_xml)
+          files = self.add_files(page_xml, page_content_dir)
           page['file_set']['files'] = files
           pages << page
         end
@@ -52,18 +60,20 @@ module PagedMedia
       end
       # Create array of files to add to page
       #
-      # @param [XML_Object] for page node to parse
+      # @param [XML_Object] page_xml page node to parse
+      # @param [String] content_dir directory for full text
       # @return [Array] of files to add to page
-      def ContentdmNewspaper.add_files(page_xml)
+      def ContentdmNewspaper.add_files(page_xml, content_dir)
         files = []
         page_xml.xpath('pagefile').each do |pagefile_xml|
           pagefile_type = pagefile_xml.xpath('pagefiletype').map(&:content).first.to_s
+          # File type should be one of: original, thumbnail, extracted
           file_type = ''
           case pagefile_type
           when 'thumbnail'
-            file_type = pagefile_type
+            file_type = 'thumbnail'
           when 'access'
-            file_type = 'image'
+            file_type = 'original'
           else
             next
           end
@@ -74,14 +84,25 @@ module PagedMedia
           file['file']['path'] = self.fix_path_iupui(path)
           files << file
         end
+        # Add extracted text
+        extracted_text_file = self.content_fulltext(page_xml, content_dir)
+        files << extracted_text_file
         return files
       end
       # Pull out fulltext from export file
       #
-      # @param [Type]  describe
+      # @param [XML_Object]  page_xml
+      # @param [String] content_dir directory for full text
       # @return [Type] description of returned object
-      def ContentdmNewspaper.content_fulltext()
-        # TODO Pull out fulltext from import file and create file to be saved
+      def ContentdmNewspaper.content_fulltext(page_xml, content_dir)
+        page_text = page_xml.xpath('pagetext').map(&:content).first.to_s
+        full_text_file = "#{content_dir}/fulltext.txt"
+        File.open(full_text_file,"w"){|f| f.write(page_text)}
+        file = {}
+        file['file'] = {}
+        file['file']['type'] = "extracted"
+        file['file']['path'] = full_text_file
+        return file
       end
       # Fix file paths for IUPUI exports
       #
@@ -106,6 +127,14 @@ module PagedMedia
         basename = Pathname.new(filename).basename.to_s.gsub('.xml', '')
         collectionname = basename.gsub('_', ' ')
 
+        # create directory if needed
+        output_dir = "spec/fixtures/ingest/#{basename}"
+        FileUtils.mkdir_p(output_dir) unless File.exists?(output_dir)
+        content_dir = "#{output_dir}/content"
+        FileUtils.mkdir_p(content_dir) unless File.exists?(content_dir)
+        full_text_dir = "#{content_dir}/fulltext"
+        FileUtils.mkdir_p(full_text_dir) unless File.exists?(full_text_dir)
+
         # create collection
         yaml['collection'] = {}
         yaml['collection']['title'] = [collectionname]
@@ -114,15 +143,13 @@ module PagedMedia
         # parse each record as an issue
         issues = []
         xml.xpath('/metadata/record').each do |record|
-          issues << self.add_newspaper(record)
+          issues << self.add_newspaper(record, full_text_dir)
         end
 
         # add issues to collection
         yaml['collection']['ordered_members'] = issues
 
-        # save output
-        output_dir = "spec/fixtures/ingest/#{basename}"
-        FileUtils.mkdir_p(output_dir) unless File.exists?(output_dir)
+        # save output YAML
         yaml_file = "#{output_dir}/manifest_#{basename}.yml"
         puts "OUTPUT: #{yaml_file}"
         File.open(yaml_file, 'w') { |f| f.write yaml.to_yaml }

--- a/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
+++ b/lib/tasks/paged_media/preingest/contentdm_newspaper.rb
@@ -64,8 +64,6 @@ module PagedMedia
             file_type = pagefile_type
           when 'access'
             file_type = 'image'
-            # TODO - When ingest can handle multiple files, include actual image.
-            next
           else
             next
           end

--- a/lib/tasks/paged_media/preingest/packages.rb
+++ b/lib/tasks/paged_media/preingest/packages.rb
@@ -1,0 +1,35 @@
+require 'fileutils'
+
+module PagedMedia
+  module PreIngest
+    module Package
+      # Find all YAML file to be copied
+      #
+      # @param [Type] dir directory to search in
+      # @return [Type] preingest files
+      def Package.preingest(dir)
+        Dir.glob(dir + "/*").select {|f| File.directory?(f)}.each do |subdir|
+          puts "Looking in: #{subdir}"
+          yml_files = Dir.glob(subdir + "/manifest_" + "*.yml").select { |f| File.file?(f) }
+          puts "YAML files found: #{yml_files.inspect}"
+          yml_files.each do |yml_file|
+            puts "YAML file: #{yml_file}"
+            self.preingest_file(yml_file, subdir)
+          end
+        end
+      end
+      # Copy file to ingest directory
+      #
+      # @param [Type] file file to copy
+      # @param [Type] subdir directory name to use
+      # @return [Type] description of returned object
+      def Package.preingest_file(file, subdir)
+        dir_basename = Pathname.new(subdir).basename.to_s
+        file_basename = Pathname.new(file).basename.to_s
+        output_file = "spec/fixtures/ingest/#{dir_basename}/#{file_basename}"
+        puts "OUTPUT: #{output_file}"
+        FileUtils.cp file, output_file
+      end
+    end
+  end
+end

--- a/spec/fixtures/preingest/packages/package1/manifest_nested.yml
+++ b/spec/fixtures/preingest/packages/package1/manifest_nested.yml
@@ -1,0 +1,32 @@
+---
+paged_work:
+  title:
+  - Nested Title 1
+  creator:
+  - Nested Author 1
+  visibility: open
+  ordered_members:
+  - container:
+      title: Nested Container 1
+      ordered_members:
+      - file_set:
+          visibility: open
+          title: 
+          - Nested File Set 1
+          file: page01.png
+      - container:
+          title: Nested Container 2
+          ordered_members:
+          - file_set:
+              visibility: open
+              title: 
+              - Nested File Set 2
+              file: page02.png
+  - container:
+      title: Nested Container 3
+      ordered_members:
+      - file_set:
+          visibility: open
+          title:
+          - Nested File Set 3
+          file: page03.png

--- a/spec/fixtures/preingest/packages/package1/manifest_simple.yml
+++ b/spec/fixtures/preingest/packages/package1/manifest_simple.yml
@@ -1,0 +1,23 @@
+---
+paged_work:
+  title:
+  - Simple Title 1
+  creator:
+  - Simple Author 1
+  visibility: open
+  ordered_members:
+  - file_set:
+      visibility: open
+      title: 
+        - Simple File Set 1
+      file: page01.png
+  - file_set:
+      visibility: open
+      title: 
+        - Simple File Set 2
+      file: page02.png
+  - file_set:
+      visibility: open
+      title: 
+        - Simple File Set 3
+      file: page03.png


### PR DESCRIPTION
Can ingest original, thumbnail, and extracted text. Also creates full text files from CDM export file and copies pre-made package YAML files into directory so that removing them while testing is not an issue.
